### PR TITLE
Use preview release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "caroucssel": {
+      "version": "0.7.0-2",
+      "resolved": "https://registry.npmjs.org/caroucssel/-/caroucssel-0.7.0-2.tgz",
+      "integrity": "sha512-99LC/FiqcA4ZGbDNdfyeNbl2vGaPD3+IgM+w3Q0fGWe+voEzufEmU9o5hvBdfIFEfPiMXmR1nz5v6cxNGvOCtw=="
+    },
     "chokidar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sass": "^1.26.10"
   },
   "dependencies": {
-    "caroucssel": "^0.6.0",
+    "caroucssel": "next",
     "normalize.css": "^8.0.1"
   }
 }


### PR DESCRIPTION
This updates caroucssel to the latest preview release (@next). The example works in my opinion from now as expected.